### PR TITLE
fix(ts): import types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Tweakpane for Vue",
   "exports": {
     ".": {
-      "import": "./dist/v-tweakpane.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/v-tweakpane.js"
     },
     "./dist/v-tweakpane.css": "./dist/v-tweakpane.css"
   },


### PR DESCRIPTION
TS sometimes does not load types if they are not listed first in the package.json file see #1663
Signed-off-by: Carl Olsen <unstoppablecarlolsen@gmail.com>